### PR TITLE
remove vanity plates

### DIFF
--- a/template.md
+++ b/template.md
@@ -31,8 +31,8 @@ Pull requests and stars are always welcome. For bugs and feature requests, [plea
 
 **<%= author.name %>**
 
-+ [github/jonschlinkert](https://github.com/jonschlinkert)
-+ [twitter/jonschlinkert](http://twitter.com/jonschlinkert)
++ [github/---](https://github.com/---)
++ [twitter/---](http://twitter.com/---)
 
 ## License
 Copyright © <%= year() %> [<%= author.name %>](<%= author.url %>)


### PR DESCRIPTION
Because maybe, just maybe, a project owner would prefer his visors to visit him & not you.  ;)

Not sure what to do;  Could lowercase & remove space to auto-fill the GitHub/Twitter names, but that will only be accurate for a %.  Could add extra fields in the [people](https://docs.npmjs.com/files/package.json#people-fields-author-contributors) field; I guess extra fields are usually ignored?
